### PR TITLE
Update casacore to 3.1.1 and make less version needy

### DIFF
--- a/casacore.rb
+++ b/casacore.rb
@@ -5,18 +5,16 @@ class Casacore < Formula
   sha256 "6f0e68fd77b5c96299f7583a03a53a90980ec347bff9dfb4c0abb0e2933e6bcb"
   head "https://github.com/casacore/casacore.git"
 
-  option "without-cxx11", "Build without C++11 support"
-
   depends_on "cmake" => :build
   depends_on "cfitsio"
-  depends_on "brewsci/science/wcslib"
+  depends_on "wcslib"
   depends_on "python@2" => :optional
   depends_on "python" => :recommended
   depends_on "fftw"
   depends_on "hdf5"
   depends_on "readline"
   depends_on "casacore-data"
-  #depends_on "gcc"
+  depends_on "gcc"  # for gfortran
 
   if build.with?("python@2")
     depends_on "boost-python"
@@ -24,7 +22,7 @@ class Casacore < Formula
   end
 
   if build.with?("python")
-    depends_on "boost-python" => "with-python"
+    depends_on "boost-python3" => "with-python"
     depends_on "numpy"
   end
 
@@ -39,7 +37,7 @@ class Casacore < Formula
     cmake_args = std_cmake_args
     cmake_args.delete "-DCMAKE_BUILD_TYPE=None"
     cmake_args << "-DCMAKE_BUILD_TYPE=#{build_type}"
-    cmake_args << "-DCXX11=False" if build.without? "cxx11"
+    cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS='-undefined dynamic_lookup'"
 
     if build.with? "python@2"
       cmake_args << "-DBUILD_PYTHON=ON"

--- a/casacore.rb
+++ b/casacore.rb
@@ -26,8 +26,13 @@ class Casacore < Formula
     depends_on "numpy"
   end
 
-  # casacore/casacore#846: Boost Python upstream fix (remove on next release)
-  patch :DATA
+  stable do
+    patch do
+      # casacore/casacore#846: Boost Python upstream fix (remove on next release)
+      url "https://gist.githubusercontent.com/ludwigschwardt/bfbe9dd2538abbbf22552fde40bec935/raw/81ecf300fd6f1605a8e30c435f51e7d93807a2b6/casacore-patch-boost-pythonxy.patch"
+      sha256 ""
+    end
+  end
 
   def install
     # To get a build type besides "release" we need to change from superenv to std env first
@@ -65,50 +70,3 @@ class Casacore < Formula
     system bin/"findmeastable", "DE405"
   end
 end
-
-__END__
-diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
-index f8ece2584..3c7b621db 100644
---- a/python/CMakeLists.txt
-+++ b/python/CMakeLists.txt
-@@ -22,7 +22,15 @@ set(Python_FIND_VERSION 2)
- set(PythonInterp_FIND_VERSION_MAJOR 2)
- find_package(Python REQUIRED)
- if (PYTHONINTERP_FOUND)
--    find_package(Boost REQUIRED COMPONENTS python)
-+    find_package(Boost REQUIRED)
-+    if (${Boost_MAJOR_VERSION} STREQUAL 1 AND ${Boost_MINOR_VERSION} STRGREATER 66)
-+        # Boost>1.67 Python components require a Python version suffix
-+        set(BOOST_PYTHON_SEARCH_VERSION python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
-+    else ()
-+        set(BOOST_PYTHON_SEARCH_VERSION python)
-+    endif ()
-+    find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_SEARCH_VERSION})
-+
-     find_package (NUMPY REQUIRED)
- 
-     # copy the variables to their final destination
-diff --git a/python3/CMakeLists.txt b/python3/CMakeLists.txt
-index 43003659b..ac7fd6924 100644
---- a/python3/CMakeLists.txt
-+++ b/python3/CMakeLists.txt
-@@ -23,12 +23,14 @@ set(Python_ADDITIONAL_VERSIONS 3.5 3.4)
- find_package(Python REQUIRED)
- 
- if (PYTHONINTERP_FOUND)
--    if (APPLE)
--        find_package(Boost REQUIRED COMPONENTS python3)
-+    find_package(Boost REQUIRED)
-+    if (${Boost_MAJOR_VERSION} STREQUAL 1 AND ${Boost_MINOR_VERSION} STRGREATER 66)
-+        # Boost>1.67 Python components require a Python version suffix
-+        set(BOOST_PYTHON_SEARCH_VERSION python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
-     else ()
--        # NOTE: the name of the python3 version of boost is probably Debian/Ubuntu specific
--        find_package(Boost REQUIRED COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
--    endif (APPLE)
-+        set(BOOST_PYTHON_SEARCH_VERSION python${PYTHON_VERSION_MAJOR})
-+    endif ()
-+    find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_SEARCH_VERSION})
- 
-     find_package (NUMPY REQUIRED)
- 

--- a/casacore.rb
+++ b/casacore.rb
@@ -3,7 +3,7 @@ class Casacore < Formula
   homepage "https://github.com/casacore/casacore"
   url "https://github.com/casacore/casacore/archive/v3.1.0.tar.gz"
   sha256 "a6adf2d77ad0d6f32995b1e297fd88d31ded9c3e0bb8f28966d7b35a969f7897"
-  head "https://github.com/casacore/casacore.git"
+  head "https://github.com/casacore/casacore.git", :branch => "improve-cmake-findpython"
 
   depends_on "cmake" => :build
   depends_on "cfitsio"
@@ -23,16 +23,11 @@ class Casacore < Formula
 
   stable do
     patch do
-      # casacore/casacore#846: Boost Python upstream fix (remove on next release)
-      url "https://gist.githubusercontent.com/ludwigschwardt/bfbe9dd2538abbbf22552fde40bec935/raw/250aff71b76bb7851b02faa88f99642d55f5db44/casacore-patch-boost-pythonxy.patch"
-      sha256 "99661f5f9132dae77bc83ae1d1d01785c0ab40a1b78956d3304d243532370784"
+      # casacore/casacore#846: Boost Python upstream fix
+      # Use FindPython2 and FindPython3 modules introduced in cmake 3.12
+      url "https://gist.githubusercontent.com/ludwigschwardt/f22e09d458aebd84c59de3013d0671ec/raw/6105f7497548a74dbe24285884cfda6127ca5526/casacore-improve-cmake-findpython-3.1.0.patch"
+      sha256 "ecd3526240ee31896afee31f1c2d8e6fb749bca9c2eeb4e578d2f3dcd217c12c"
     end
-  end
-
-  patch do
-    # Use FindPython2 and FindPython3 modules introduced in cmake 3.12
-    url "https://gist.githubusercontent.com/ludwigschwardt/0bfaef7b2c6832fb018332742e14924e/raw/85002935f06cc821b9bda8246f5a950220e23f9e/casacore-cmake-findpython.patch"
-    sha256 "602a5e4728e972167575f39cfc451d91a0c9121b1b247b6eff8e480ccb96b791"
   end
 
   def install

--- a/casacore.rb
+++ b/casacore.rb
@@ -1,8 +1,8 @@
 class Casacore < Formula
   desc "Suite of C++ libraries for radio astronomy data processing"
   homepage "https://github.com/casacore/casacore"
-  url "https://github.com/casacore/casacore/archive/v2.4.1.tar.gz"
-  sha256 "58eccc875053b2c6fe44fe53b6463030ef169597ec29926936f18d27b5087d63"
+  url "https://github.com/casacore/casacore/archive/v3.0.0.tar.gz"
+  sha256 "6f0e68fd77b5c96299f7583a03a53a90980ec347bff9dfb4c0abb0e2933e6bcb"
   head "https://github.com/casacore/casacore.git"
 
   option "without-cxx11", "Build without C++11 support"
@@ -10,24 +10,21 @@ class Casacore < Formula
   depends_on "cmake" => :build
   depends_on "cfitsio"
   depends_on "brewsci/science/wcslib"
-  depends_on "python@2" => :recommended
-  depends_on "python" => :optional
+  depends_on "python@2" => :optional
+  depends_on "python" => :recommended
   depends_on "fftw"
   depends_on "hdf5"
   depends_on "readline"
   depends_on "casacore-data"
-  depends_on "gcc"
+  #depends_on "gcc"
 
   if build.with?("python@2")
-    # Boost 1.67 changed the Python library name and cmake 3.11.3 doesn't like it
-    # Remove the version pin once cmake catches up
-    # See https://gitlab.kitware.com/cmake/cmake/merge_requests/1865
-    depends_on "boost-python@1.59"
+    depends_on "boost-python"
     depends_on "numpy"
   end
 
   if build.with?("python")
-    depends_on "boost-python@1.59" => "with-python"
+    depends_on "boost-python" => "with-python"
     depends_on "numpy"
   end
 
@@ -45,8 +42,6 @@ class Casacore < Formula
       cmake_args << "-DBUILD_PYTHON=ON"
       cmake_args << "-DPYTHON2_EXECUTABLE=/usr/local/bin/python2"
       cmake_args << "-DPYTHON2_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib"
-      # XXX Remove once cmake handles Boost 1.67
-      cmake_args << "-DBOOST_ROOT=/usr/local/opt/boost@1.59;/usr/local/opt/boost-python@1.59"
     else
       cmake_args << "-DBUILD_PYTHON=OFF"
     end
@@ -54,9 +49,7 @@ class Casacore < Formula
     if build.with? "python"
       cmake_args << "-DBUILD_PYTHON3=ON"
       cmake_args << "-DPYTHON3_EXECUTABLE=/usr/local/bin/python3"
-      cmake_args << "-DPYTHON3_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6.dylib"
-      # XXX Remove once cmake handles Boost 1.67
-      cmake_args << "-DBOOST_ROOT=/usr/local/opt/boost@1.59;/usr/local/opt/boost-python@1.59"
+      cmake_args << "-DPYTHON3_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib"
     end
 
     cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"

--- a/casacore.rb
+++ b/casacore.rb
@@ -1,9 +1,9 @@
 class Casacore < Formula
   desc "Suite of C++ libraries for radio astronomy data processing"
   homepage "https://github.com/casacore/casacore"
-  url "https://github.com/casacore/casacore/archive/v3.1.0.tar.gz"
-  sha256 "a6adf2d77ad0d6f32995b1e297fd88d31ded9c3e0bb8f28966d7b35a969f7897"
-  head "https://github.com/casacore/casacore.git", :branch => "improve-cmake-findpython"
+  url "https://github.com/casacore/casacore/archive/v3.1.1.tar.gz"
+  sha256 "85d2b17d856592fb206b17e0a344a29330650a4269c80b87f8abb3eaf3dadad4"
+  head "https://github.com/casacore/casacore.git"
 
   depends_on "cmake" => :build
   depends_on "cfitsio"
@@ -19,15 +19,6 @@ class Casacore < Formula
 
   if build.with?("python")
     depends_on "boost-python3"
-  end
-
-  stable do
-    patch do
-      # casacore/casacore#846: Boost Python upstream fix
-      # Use FindPython2 and FindPython3 modules introduced in cmake 3.12
-      url "https://gist.githubusercontent.com/ludwigschwardt/f22e09d458aebd84c59de3013d0671ec/raw/6105f7497548a74dbe24285884cfda6127ca5526/casacore-improve-cmake-findpython-3.1.0.patch"
-      sha256 "ecd3526240ee31896afee31f1c2d8e6fb749bca9c2eeb4e578d2f3dcd217c12c"
-    end
   end
 
   def install

--- a/casacore.rb
+++ b/casacore.rb
@@ -50,15 +50,9 @@ class Casacore < Formula
     cmake_args << "-DCMAKE_BUILD_TYPE=#{build_type}"
     cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS='-undefined dynamic_lookup'"
 
-    if build.with? "python@2"
-      cmake_args << "-DBUILD_PYTHON=ON"
-    else
-      cmake_args << "-DBUILD_PYTHON=OFF"
-    end
-
-    if build.with? "python"
-      cmake_args << "-DBUILD_PYTHON3=ON"
-    end
+    cmake_args << "-DBUILD_PYTHON=ON" if build.with? "python@2"
+    cmake_args << "-DBUILD_PYTHON=OFF" if build.without? "python@2"
+    cmake_args << "-DBUILD_PYTHON3=ON" if build.with? "python"
 
     cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"
     cmake_args << "-DUSE_HDF5=ON" << "-DHDF5_ROOT_DIR=#{HOMEBREW_PREFIX}"

--- a/casacore.rb
+++ b/casacore.rb
@@ -29,15 +29,15 @@ class Casacore < Formula
   stable do
     patch do
       # casacore/casacore#846: Boost Python upstream fix (remove on next release)
-      url "https://gist.githubusercontent.com/ludwigschwardt/bfbe9dd2538abbbf22552fde40bec935/raw/81ecf300fd6f1605a8e30c435f51e7d93807a2b6/casacore-patch-boost-pythonxy.patch"
-      sha256 "f0a05f9c1d990d5adf5fbb54b8ed662a7072b79f54d11a4f1c02589cb1e8ad51"
+      url "https://gist.githubusercontent.com/ludwigschwardt/bfbe9dd2538abbbf22552fde40bec935/raw/250aff71b76bb7851b02faa88f99642d55f5db44/casacore-patch-boost-pythonxy.patch"
+      sha256 "99661f5f9132dae77bc83ae1d1d01785c0ab40a1b78956d3304d243532370784"
     end
   end
 
   patch do
     # Use FindPython2 and FindPython3 modules introduced in cmake 3.12
-    url "https://gist.githubusercontent.com/ludwigschwardt/0bfaef7b2c6832fb018332742e14924e/raw/5309939f68b8a07e458c5b599c06ec8f97990da5/casacore-cmake-findpython.patch"
-    sha256 "a4eefefdba3d7f9829c197fd88de502e8a1c4379282aa3200fcedfa7f42b0e6a"
+    url "https://gist.githubusercontent.com/ludwigschwardt/0bfaef7b2c6832fb018332742e14924e/raw/85002935f06cc821b9bda8246f5a950220e23f9e/casacore-cmake-findpython.patch"
+    sha256 "602a5e4728e972167575f39cfc451d91a0c9121b1b247b6eff8e480ccb96b791"
   end
 
   def install

--- a/casacore.rb
+++ b/casacore.rb
@@ -34,6 +34,12 @@ class Casacore < Formula
     end
   end
 
+  patch do
+    # Use FindPython2 and FindPython3 modules introduced in cmake 3.12
+    url "https://gist.githubusercontent.com/ludwigschwardt/0bfaef7b2c6832fb018332742e14924e/raw/5309939f68b8a07e458c5b599c06ec8f97990da5/casacore-cmake-findpython.patch"
+    sha256 ""
+  end
+
   def install
     # To get a build type besides "release" we need to change from superenv to std env first
     build_type = "release"
@@ -46,16 +52,12 @@ class Casacore < Formula
 
     if build.with? "python@2"
       cmake_args << "-DBUILD_PYTHON=ON"
-      cmake_args << "-DPYTHON2_EXECUTABLE=/usr/local/bin/python2"
-      cmake_args << "-DPYTHON2_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/2.7/lib/libpython2.7.dylib"
     else
       cmake_args << "-DBUILD_PYTHON=OFF"
     end
 
     if build.with? "python"
       cmake_args << "-DBUILD_PYTHON3=ON"
-      cmake_args << "-DPYTHON3_EXECUTABLE=/usr/local/bin/python3"
-      cmake_args << "-DPYTHON3_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib"
     end
 
     cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"

--- a/casacore.rb
+++ b/casacore.rb
@@ -28,6 +28,9 @@ class Casacore < Formula
     depends_on "numpy"
   end
 
+  # casacore/casacore#846: Boost Python upstream fix (remove on next release)
+  patch :DATA
+
   def install
     # To get a build type besides "release" we need to change from superenv to std env first
     build_type = "release"
@@ -64,3 +67,50 @@ class Casacore < Formula
     system bin/"findmeastable", "DE405"
   end
 end
+
+__END__
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index f8ece2584..3c7b621db 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -22,7 +22,15 @@ set(Python_FIND_VERSION 2)
+ set(PythonInterp_FIND_VERSION_MAJOR 2)
+ find_package(Python REQUIRED)
+ if (PYTHONINTERP_FOUND)
+-    find_package(Boost REQUIRED COMPONENTS python)
++    find_package(Boost REQUIRED)
++    if (${Boost_MAJOR_VERSION} STREQUAL 1 AND ${Boost_MINOR_VERSION} STRGREATER 66)
++        # Boost>1.67 Python components require a Python version suffix
++        set(BOOST_PYTHON_SEARCH_VERSION python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
++    else ()
++        set(BOOST_PYTHON_SEARCH_VERSION python)
++    endif ()
++    find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_SEARCH_VERSION})
++
+     find_package (NUMPY REQUIRED)
+ 
+     # copy the variables to their final destination
+diff --git a/python3/CMakeLists.txt b/python3/CMakeLists.txt
+index 43003659b..ac7fd6924 100644
+--- a/python3/CMakeLists.txt
++++ b/python3/CMakeLists.txt
+@@ -23,12 +23,14 @@ set(Python_ADDITIONAL_VERSIONS 3.5 3.4)
+ find_package(Python REQUIRED)
+ 
+ if (PYTHONINTERP_FOUND)
+-    if (APPLE)
+-        find_package(Boost REQUIRED COMPONENTS python3)
++    find_package(Boost REQUIRED)
++    if (${Boost_MAJOR_VERSION} STREQUAL 1 AND ${Boost_MINOR_VERSION} STRGREATER 66)
++        # Boost>1.67 Python components require a Python version suffix
++        set(BOOST_PYTHON_SEARCH_VERSION python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+     else ()
+-        # NOTE: the name of the python3 version of boost is probably Debian/Ubuntu specific
+-        find_package(Boost REQUIRED COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+-    endif (APPLE)
++        set(BOOST_PYTHON_SEARCH_VERSION python${PYTHON_VERSION_MAJOR})
++    endif ()
++    find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_SEARCH_VERSION})
+ 
+     find_package (NUMPY REQUIRED)
+ 

--- a/casacore.rb
+++ b/casacore.rb
@@ -30,14 +30,14 @@ class Casacore < Formula
     patch do
       # casacore/casacore#846: Boost Python upstream fix (remove on next release)
       url "https://gist.githubusercontent.com/ludwigschwardt/bfbe9dd2538abbbf22552fde40bec935/raw/81ecf300fd6f1605a8e30c435f51e7d93807a2b6/casacore-patch-boost-pythonxy.patch"
-      sha256 ""
+      sha256 "f0a05f9c1d990d5adf5fbb54b8ed662a7072b79f54d11a4f1c02589cb1e8ad51"
     end
   end
 
   patch do
     # Use FindPython2 and FindPython3 modules introduced in cmake 3.12
     url "https://gist.githubusercontent.com/ludwigschwardt/0bfaef7b2c6832fb018332742e14924e/raw/5309939f68b8a07e458c5b599c06ec8f97990da5/casacore-cmake-findpython.patch"
-    sha256 ""
+    sha256 "a4eefefdba3d7f9829c197fd88de502e8a1c4379282aa3200fcedfa7f42b0e6a"
   end
 
   def install

--- a/casacore.rb
+++ b/casacore.rb
@@ -1,8 +1,8 @@
 class Casacore < Formula
   desc "Suite of C++ libraries for radio astronomy data processing"
   homepage "https://github.com/casacore/casacore"
-  url "https://github.com/casacore/casacore/archive/v3.0.0.tar.gz"
-  sha256 "6f0e68fd77b5c96299f7583a03a53a90980ec347bff9dfb4c0abb0e2933e6bcb"
+  url "https://github.com/casacore/casacore/archive/v3.1.0.tar.gz"
+  sha256 "a6adf2d77ad0d6f32995b1e297fd88d31ded9c3e0bb8f28966d7b35a969f7897"
   head "https://github.com/casacore/casacore.git"
 
   depends_on "cmake" => :build

--- a/casacore.rb
+++ b/casacore.rb
@@ -22,7 +22,7 @@ class Casacore < Formula
   end
 
   if build.with?("python")
-    depends_on "boost-python3" => "with-python"
+    depends_on "boost-python3"
     depends_on "numpy"
   end
 

--- a/casacore.rb
+++ b/casacore.rb
@@ -8,22 +8,17 @@ class Casacore < Formula
   depends_on "cmake" => :build
   depends_on "cfitsio"
   depends_on "wcslib"
-  depends_on "python@2" => :optional
-  depends_on "python" => :recommended
   depends_on "fftw"
   depends_on "hdf5"
   depends_on "readline"
-  depends_on "casacore-data"
   depends_on "gcc"  # for gfortran
-
-  if build.with?("python@2")
-    depends_on "boost-python"
-    depends_on "numpy"
-  end
+  depends_on "python" => :recommended
+  depends_on "boost-python"
+  depends_on "numpy"
+  depends_on "casacore-data"
 
   if build.with?("python")
     depends_on "boost-python3"
-    depends_on "numpy"
   end
 
   stable do
@@ -49,11 +44,8 @@ class Casacore < Formula
     cmake_args.delete "-DCMAKE_BUILD_TYPE=None"
     cmake_args << "-DCMAKE_BUILD_TYPE=#{build_type}"
     cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS='-undefined dynamic_lookup'"
-
-    cmake_args << "-DBUILD_PYTHON=ON" if build.with? "python@2"
-    cmake_args << "-DBUILD_PYTHON=OFF" if build.without? "python@2"
+    cmake_args << "-DBUILD_PYTHON=ON"
     cmake_args << "-DBUILD_PYTHON3=ON" if build.with? "python"
-
     cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"
     cmake_args << "-DUSE_HDF5=ON" << "-DHDF5_ROOT_DIR=#{HOMEBREW_PREFIX}"
     cmake_args << "-DUSE_THREADS=ON" << "-DDATA_DIR=#{HOMEBREW_PREFIX}/share/casacore/data"


### PR DESCRIPTION
unfortunately this still can't find the new boost python.

a minimal `CMakeLists.txt` like:
```
cmake_minimum_required(VERSION 3.13)
find_package(Boost REQUIRED COMPONENTS python)
```
still gives:
```
$  cmake ..
CMake Error at /usr/local/Cellar/cmake/3.13.1/share/cmake/Modules/FindBoost.cmake:2100 (message):
  Unable to find the requested Boost libraries.

  Boost version: 1.68.0

  Boost include path: /usr/local/include

  Could not find the following Boost libraries:

          boost_python

  No Boost libraries were found.  You may need to set BOOST_LIBRARYDIR to the
  directory containing Boost libraries or BOOST_ROOT to the location of
  Boost.
Call Stack (most recent call first):
  CMakeLists.txt:2 (find_package)


-- Configuring incomplete, errors occurred!
See also "/Users/gijs/bla/build/CMakeFiles/CMakeOutput.log".
```

with `cmake 3.13.1` and boost `1.68.0` while it looks like this bug has been fixed since `cmake 3.11.0`

https://gitlab.kitware.com/cmake/cmake/commit/1673923c303c6a4184904c4c5849911feddb87e7