### PR TITLE
[ska-sa/homebrew-tap#24] Update formulas for homebrew 3.0

### DIFF
--- a/casacore.rb
+++ b/casacore.rb
@@ -1,80 +1,60 @@
 class Casacore < Formula
   desc "Suite of C++ libraries for radio astronomy data processing"
   homepage "https://github.com/casacore/casacore"
-  url "https://github.com/casacore/casacore/archive/v3.1.1.tar.gz"
-  sha256 "85d2b17d856592fb206b17e0a344a29330650a4269c80b87f8abb3eaf3dadad4"
+  url "https://github.com/casacore/casacore/archive/v3.4.0.tar.gz"
+  sha256 "31f02ad2e26f29bab4a47a2a69e049d7bc511084a0b8263360e6157356f92ae1"
   head "https://github.com/casacore/casacore.git"
 
   depends_on "cmake" => :build
-  depends_on "cfitsio"
-  depends_on "wcslib"
   depends_on "fftw"
   depends_on "hdf5"
-  depends_on "readline"
+  depends_on "cfitsio"
+  depends_on "wcslib"
   depends_on "gcc"  # for gfortran
-  depends_on "python" => :recommended
-  depends_on "boost-python"
-  depends_on "numpy"
+  depends_on "readline"
+
   depends_on "casacore-data"
 
-  if build.with?("python")
-    depends_on "boost-python3"
-  end
+  option "with-python", "Build Python bindings"
 
   patch :DATA
 
+  if build.with?("python")
+    depends_on "python3"
+    depends_on "numpy"
+    depends_on "boost-python3"
+  end
+
   def install
+    casacore_data = HOMEBREW_PREFIX / "opt/casacore-data/data"
+    if !casacore_data.exist?
+      opoo "casacore data not found at #{casacore_data}"
+    end
     # To get a build type besides "release" we need to change from superenv to std env first
     build_type = "release"
-    mkdir_p "build/#{build_type}"
-    cd "build/#{build_type}"
-    cmake_args = std_cmake_args
-    cmake_args.delete "-DCMAKE_BUILD_TYPE=None"
-    cmake_args << "-DCMAKE_BUILD_TYPE=#{build_type}"
-    cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS='-undefined dynamic_lookup'"
-    cmake_args << "-DCMAKE_MODULE_LINKER_FLAGS='-undefined dynamic_lookup'"
-    cmake_args << "-DBUILD_PYTHON=ON"
-    cmake_args << "-DBUILD_PYTHON3=ON" if build.with? "python"
-    cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"
-    cmake_args << "-DUSE_HDF5=ON" << "-DHDF5_ROOT_DIR=#{HOMEBREW_PREFIX}"
-    cmake_args << "-DUSE_THREADS=ON" << "-DDATA_DIR=#{HOMEBREW_PREFIX}/share/casacore/data"
-    system "cmake", "../..", *cmake_args
-    system "make", "install"
+    mkdir "build/#{build_type}" do
+      cmake_args = std_cmake_args
+      cmake_args.delete "-DCMAKE_BUILD_TYPE=None"
+      cmake_args << "-DCMAKE_BUILD_TYPE=#{build_type}"
+      cmake_args << "-DBUILD_PYTHON=OFF"
+      cmake_args << "-DBUILD_PYTHON3=#{(build.with? "python") ? "ON" : "OFF"}"
+      cmake_args << "-DUSE_OPENMP=OFF"
+      cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"
+      cmake_args << "-DUSE_HDF5=ON" << "-DHDF5_ROOT_DIR=#{HOMEBREW_PREFIX}"
+      cmake_args << "-DBoost_NO_BOOST_CMAKE=True"
+      cmake_args << "-DDATA_DIR=#{HOMEBREW_PREFIX / "opt/casacore-data/data"}"
+      system "cmake", "../..", *cmake_args
+      system "make", "install"
+    end
   end
 
   test do
-    system bin/"findmeastable", "IGRF"
-    system bin/"findmeastable", "DE405"
+    system bin / "findmeastable", "IGRF"
+    system bin / "findmeastable", "DE405"
   end
 end
 
 __END__
-diff --git a/python/CMakeLists-cmake3.12.txt b/python/CMakeLists-cmake3.12.txt
-index 7c981f7..49c89cc 100644
---- a/python/CMakeLists-cmake3.12.txt
-+++ b/python/CMakeLists-cmake3.12.txt
-@@ -60,7 +60,7 @@ Converters/PycValueHolder.h
- Converters/PycArray.tcc
- )
- 
--target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${PYTHON2_LIBRARIES} ${CASACORE_ARCH_LIBS})
-+target_link_libraries (casa_python casa_casa ${PYTHON2_Boost_LIBRARIES} ${CASACORE_ARCH_LIBS})
- 
- install (TARGETS casa_python
- RUNTIME DESTINATION bin
-diff --git a/python3/CMakeLists-cmake3.12.txt b/python3/CMakeLists-cmake3.12.txt
-index 26d5ca5..8db7fec 100644
---- a/python3/CMakeLists-cmake3.12.txt
-+++ b/python3/CMakeLists-cmake3.12.txt
-@@ -51,7 +51,7 @@ add_library (casa_python3
- )
- 
- 
--target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES} ${PYTHON3_LIBRARIES})
-+target_link_libraries (casa_python3 casa_casa ${PYTHON3_Boost_LIBRARIES})
- 
- install (TARGETS casa_python3
- RUNTIME DESTINATION bin
 diff --git a/python/Converters/test/CMakeLists.txt b/python/Converters/test/CMakeLists.txt
 index 32214a8..321c98b 100644
 --- a/python/Converters/test/CMakeLists.txt

--- a/psrchive.rb
+++ b/psrchive.rb
@@ -22,7 +22,12 @@ class Psrchive < Formula
     patch :DATA
   end
 
-  depends_on :x11
+  option "with-x11", "Experimental: build with x11 support"
+  
+  if build.with? "x11"
+    depends_on "libx11" => :recommended
+  end
+  
   depends_on "gcc"
 
   depends_on "pgplot"

--- a/tempo2.rb
+++ b/tempo2.rb
@@ -4,7 +4,7 @@ class Tempo2 < Formula
   url "https://downloads.sourceforge.net/tempo2/tempo2-2013.9.1.tar.gz"
   sha256 "79dede8fcb4deb66789d6acffa775cfc27ed33412eb795c93aad4dbe054cd933"
 
-  depends_on :x11
+  depends_on "libx11" => :recommended
   depends_on "gcc"
 
   depends_on "pgplot"

--- a/xpra.rb
+++ b/xpra.rb
@@ -15,7 +15,7 @@ class Xpra < Formula
   # PyOpenGL is only required if pygtkglext is to be used
   depends_on "OpenGL" if build.with? "pygtkglext"
   depends_on "OpenGL_accelerate" if build.with? "pygtkglext"
-  depends_on :x11
+  depends_on "libx11" => :recommended
   depends_on "pygtk"
   depends_on "pygtkglext" => :recommended
   depends_on "gtk-mac-integration"


### PR DESCRIPTION
- replace `depends_on :x11` with `libx11`
- fixe undefined method `verbose?' for ARGV
- chdir after `UnpackStrategy::Tar.extract` to prevent Empty Install error
- replace `--use-casapy` option for `with-casapy` (no longer possible)
- fix https://github.com/ska-sa/homebrew-tap/issues/24
- die if specify `--with-casapy` but data is missing
- upgrade to casacore v3.4.0
- remove broken patches
- follow homebrew 3.0 [guidelines for formulas](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md)
- ruby autofmt